### PR TITLE
Add draft comment tools: post, list, delete single, and delete all

### DIFF
--- a/gerrit_mcp_server/main.py
+++ b/gerrit_mcp_server/main.py
@@ -224,6 +224,11 @@ def _create_put_args(url: str, payload: Optional[Dict[str, Any]] = None) -> List
     return args
 
 
+def _create_delete_args(url: str) -> List[str]:
+    """Creates the argument list for a curl DELETE request."""
+    return ["-X", "DELETE", url]
+
+
 # --- Tool Implementations ---
 
 
@@ -1178,7 +1183,7 @@ async def post_review_comment(
     }
     if labels:
         payload["labels"] = labels
-    
+
     args = _create_post_args(url, payload)
 
     try:
@@ -1205,6 +1210,182 @@ async def post_review_comment(
             )
         raise e
 
+
+@mcp.tool()
+async def post_draft_comment(
+    change_id: str,
+    file_path: str,
+    line_number: int,
+    message: str,
+    unresolved: bool = True,
+    gerrit_base_url: Optional[str] = None,
+    start_line: Optional[int] = None,
+    start_character: Optional[int] = None,
+    end_line: Optional[int] = None,
+    end_character: Optional[int] = None,
+    suggestion: Optional[str] = None,
+):
+    """
+    Creates a draft review comment on a specific line of a file in a CL.
+    Draft comments are only visible to the author until explicitly published.
+
+    """
+    if suggestion is not None:
+        message = message + f"\n```suggestion\n{suggestion}\n```"
+
+    config = load_gerrit_config()
+    gerrit_hosts = config.get("gerrit_hosts", [])
+    base_url = _normalize_gerrit_url(_get_gerrit_base_url(gerrit_base_url), gerrit_hosts)
+    url = f"{base_url}/changes/{change_id}/revisions/current/drafts"
+
+    payload: Dict[str, Any] = {
+        "path": file_path,
+        "line": line_number,
+        "message": message,
+        "unresolved": unresolved,
+    }
+
+    if all(v is not None for v in [start_line, start_character, end_line, end_character]):
+        payload["range"] = {
+            "start_line": start_line,
+            "start_character": start_character,
+            "end_line": end_line,
+            "end_character": end_character,
+        }
+        # Gerrit requires line to equal end_line when a range is provided.
+        payload["line"] = end_line
+
+    args = _create_put_args(url, payload)
+
+    try:
+        result_str = await run_curl(args, base_url)
+        result = json.loads(result_str)
+        if "id" in result:
+            return [
+                {
+                    "type": "text",
+                    "text": f"Draft comment created on CL {change_id}, file {file_path} at line {line_number}.",
+                }
+            ]
+        else:
+            return [
+                {
+                    "type": "text",
+                    "text": f"Failed to create draft comment. Response: {result_str}",
+                }
+            ]
+    except Exception as e:
+        with open(LOG_FILE_PATH, "a") as log_file:
+            log_file.write(
+                f"[gerrit-mcp-server] Error creating draft comment on CL {change_id}: {e}\n"
+            )
+        raise e
+
+
+@mcp.tool()
+async def list_draft_comments(
+    change_id: str, gerrit_base_url: Optional[str] = None
+):
+    """
+    Lists all draft comments on a CL.
+    """
+    config = load_gerrit_config()
+    gerrit_hosts = config.get("gerrit_hosts", [])
+    base_url = _normalize_gerrit_url(_get_gerrit_base_url(gerrit_base_url), gerrit_hosts)
+    url = f"{base_url}/changes/{change_id}/revisions/current/drafts"
+
+    result_str = await run_curl([url], base_url)
+    try:
+        drafts_by_file = json.loads(result_str)
+    except json.JSONDecodeError:
+        return [{"type": "text", "text": f"Failed to parse drafts response.\n{result_str}"}]
+
+    if not drafts_by_file:
+        return [{"type": "text", "text": f"No draft comments on CL {change_id}."}]
+
+    output = f"Draft comments on CL {change_id}:\n"
+    total = 0
+    for file_path, drafts in drafts_by_file.items():
+        output += f"---\nFile: {file_path}\n"
+        for draft in drafts:
+            draft_id = draft.get("id", "?")
+            line = draft.get("line", "file")
+            message = draft.get("message", "")
+            preview = message[:120].replace("\n", " ")
+            output += f"  [{draft_id}] L{line}: {preview}\n"
+            total += 1
+
+    output += f"---\nTotal: {total} draft(s)\n"
+    return [{"type": "text", "text": output}]
+
+
+async def _delete_draft_comment(base_url: str, change_id: str, draft_id: str):
+    """Deletes a single draft comment by ID."""
+    delete_url = f"{base_url}/changes/{change_id}/revisions/current/drafts/{draft_id}"
+    await run_curl(_create_delete_args(delete_url), base_url)
+
+
+@mcp.tool()
+async def delete_draft_comment(
+    change_id: str, draft_id: str, gerrit_base_url: Optional[str] = None
+):
+    """
+    Deletes a single draft comment on a CL by its draft ID.
+    """
+    config = load_gerrit_config()
+    gerrit_hosts = config.get("gerrit_hosts", [])
+    base_url = _normalize_gerrit_url(_get_gerrit_base_url(gerrit_base_url), gerrit_hosts)
+
+    try:
+        await _delete_draft_comment(base_url, change_id, draft_id)
+        return [{"type": "text", "text": f"Deleted draft comment {draft_id} on CL {change_id}."}]
+    except Exception as e:
+        with open(LOG_FILE_PATH, "a") as log_file:
+            log_file.write(
+                f"[gerrit-mcp-server] Error deleting draft {draft_id} on CL {change_id}: {e}\n"
+            )
+        raise e
+
+
+@mcp.tool()
+async def delete_draft_comments(
+    change_id: str, gerrit_base_url: Optional[str] = None
+):
+    """
+    Deletes ALL draft comments on a CL.
+    """
+    config = load_gerrit_config()
+    gerrit_hosts = config.get("gerrit_hosts", [])
+    base_url = _normalize_gerrit_url(_get_gerrit_base_url(gerrit_base_url), gerrit_hosts)
+
+    # First, list all drafts
+    list_url = f"{base_url}/changes/{change_id}/revisions/current/drafts"
+    result_str = await run_curl([list_url], base_url)
+    try:
+        drafts_by_file = json.loads(result_str)
+    except json.JSONDecodeError:
+        return [{"type": "text", "text": f"Failed to parse drafts response.\n{result_str}"}]
+
+    if not drafts_by_file:
+        return [{"type": "text", "text": f"No draft comments to delete on CL {change_id}."}]
+
+    deleted = 0
+    errors = []
+    for file_path, drafts in drafts_by_file.items():
+        for draft in drafts:
+            draft_id = draft.get("id")
+            if not draft_id:
+                continue
+            try:
+                await _delete_draft_comment(base_url, change_id, draft_id)
+                deleted += 1
+            except Exception as e:
+                errors.append(f"  Failed to delete {draft_id} on {file_path}: {e}")
+
+    output = f"Deleted {deleted} draft comment(s) on CL {change_id}."
+    if errors:
+        output += f"\n{len(errors)} error(s):\n" + "\n".join(errors)
+    return [{"type": "text", "text": output}]
 
 
 def cli_main(argv: List[str]):

--- a/tests/unit/test_delete_draft_comments.py
+++ b/tests/unit/test_delete_draft_comments.py
@@ -1,0 +1,162 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import patch, AsyncMock, call
+
+from gerrit_mcp_server import main
+
+
+BASE_URL = "https://gerrit-review.googlesource.com"
+
+
+class TestDeleteDraftComment(unittest.TestCase):
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_delete_single_draft_success(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.return_value = ""
+
+            result = await main.delete_draft_comment(
+                change_id="123",
+                draft_id="draft-abc",
+                gerrit_base_url=BASE_URL,
+            )
+
+            self.assertIn("Deleted draft comment draft-abc on CL 123", result[0]["text"])
+            mock_run_curl.assert_called_once()
+            args, _ = mock_run_curl.call_args
+            curl_args = args[0]
+            self.assertIn("-X", curl_args)
+            self.assertIn("DELETE", curl_args)
+            self.assertIn(
+                f"{BASE_URL}/changes/123/revisions/current/drafts/draft-abc",
+                curl_args,
+            )
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_delete_single_draft_exception(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.side_effect = Exception("Not found")
+
+            with self.assertRaises(Exception):
+                await main.delete_draft_comment(
+                    change_id="123",
+                    draft_id="draft-abc",
+                    gerrit_base_url=BASE_URL,
+                )
+
+        asyncio.run(run_test())
+
+
+class TestDeleteDraftComments(unittest.TestCase):
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_delete_all_drafts_success(self, mock_run_curl):
+        async def run_test():
+            drafts_response = {
+                "src/main.py": [
+                    {"id": "draft-001"},
+                    {"id": "draft-002"},
+                ],
+                "README.md": [
+                    {"id": "draft-003"},
+                ],
+            }
+            # First call returns the list, subsequent calls are deletes
+            mock_run_curl.side_effect = [
+                json.dumps(drafts_response),
+                "",  # delete draft-001
+                "",  # delete draft-002
+                "",  # delete draft-003
+            ]
+
+            result = await main.delete_draft_comments(
+                change_id="123", gerrit_base_url=BASE_URL
+            )
+
+            self.assertIn("Deleted 3 draft comment(s)", result[0]["text"])
+            self.assertEqual(mock_run_curl.call_count, 4)  # 1 list + 3 deletes
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_delete_all_drafts_empty(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.return_value = json.dumps({})
+
+            result = await main.delete_draft_comments(
+                change_id="123", gerrit_base_url=BASE_URL
+            )
+
+            self.assertIn("No draft comments to delete", result[0]["text"])
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_delete_all_drafts_parse_error(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.return_value = "not json"
+
+            result = await main.delete_draft_comments(
+                change_id="123", gerrit_base_url=BASE_URL
+            )
+
+            self.assertIn("Failed to parse drafts response", result[0]["text"])
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_delete_all_drafts_partial_failure(self, mock_run_curl):
+        async def run_test():
+            drafts_response = {
+                "file.py": [
+                    {"id": "draft-001"},
+                    {"id": "draft-002"},
+                ],
+            }
+            mock_run_curl.side_effect = [
+                json.dumps(drafts_response),
+                "",  # draft-001 succeeds
+                Exception("Server error"),  # draft-002 fails
+            ]
+
+            result = await main.delete_draft_comments(
+                change_id="123", gerrit_base_url=BASE_URL
+            )
+
+            text = result[0]["text"]
+            self.assertIn("Deleted 1 draft comment(s)", text)
+            self.assertIn("1 error(s)", text)
+            self.assertIn("draft-002", text)
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_delete_all_drafts_skips_missing_ids(self, mock_run_curl):
+        async def run_test():
+            drafts_response = {
+                "file.py": [
+                    {"id": "draft-001"},
+                    {"message": "no id field"},  # missing id
+                ],
+            }
+            mock_run_curl.side_effect = [
+                json.dumps(drafts_response),
+                "",  # delete draft-001
+            ]
+
+            result = await main.delete_draft_comments(
+                change_id="123", gerrit_base_url=BASE_URL
+            )
+
+            self.assertIn("Deleted 1 draft comment(s)", result[0]["text"])
+            # 1 list + 1 delete (skipped the one without id)
+            self.assertEqual(mock_run_curl.call_count, 2)
+
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_list_draft_comments.py
+++ b/tests/unit/test_list_draft_comments.py
@@ -1,0 +1,107 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import patch, AsyncMock
+
+from gerrit_mcp_server import main
+
+
+class TestListDraftComments(unittest.TestCase):
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_list_draft_comments_success(self, mock_run_curl):
+        async def run_test():
+            mock_response = {
+                "src/main.py": [
+                    {
+                        "id": "draft-001",
+                        "line": 10,
+                        "message": "This needs fixing.",
+                    },
+                    {
+                        "id": "draft-002",
+                        "line": 25,
+                        "message": "Consider refactoring this block.",
+                    },
+                ],
+                "README.md": [
+                    {
+                        "id": "draft-003",
+                        "line": 3,
+                        "message": "Typo here.",
+                    }
+                ],
+            }
+            mock_run_curl.return_value = json.dumps(mock_response)
+
+            result = await main.list_draft_comments(
+                change_id="789",
+                gerrit_base_url="https://gerrit-review.googlesource.com",
+            )
+
+            text = result[0]["text"]
+            self.assertIn("Draft comments on CL 789", text)
+            self.assertIn("File: src/main.py", text)
+            self.assertIn("[draft-001] L10", text)
+            self.assertIn("This needs fixing.", text)
+            self.assertIn("[draft-002] L25", text)
+            self.assertIn("File: README.md", text)
+            self.assertIn("[draft-003] L3", text)
+            self.assertIn("Total: 3 draft(s)", text)
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_list_draft_comments_empty(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.return_value = json.dumps({})
+
+            result = await main.list_draft_comments(
+                change_id="789",
+                gerrit_base_url="https://gerrit-review.googlesource.com",
+            )
+
+            self.assertIn("No draft comments on CL 789", result[0]["text"])
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_list_draft_comments_parse_error(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.return_value = "not valid json"
+
+            result = await main.list_draft_comments(
+                change_id="789",
+                gerrit_base_url="https://gerrit-review.googlesource.com",
+            )
+
+            self.assertIn("Failed to parse drafts response", result[0]["text"])
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_list_draft_comments_truncates_long_messages(self, mock_run_curl):
+        async def run_test():
+            long_message = "x" * 200
+            mock_response = {
+                "file.py": [
+                    {"id": "d1", "line": 1, "message": long_message},
+                ],
+            }
+            mock_run_curl.return_value = json.dumps(mock_response)
+
+            result = await main.list_draft_comments(
+                change_id="789",
+                gerrit_base_url="https://gerrit-review.googlesource.com",
+            )
+
+            text = result[0]["text"]
+            # Preview is truncated to 120 chars
+            self.assertNotIn("x" * 200, text)
+            self.assertIn("x" * 120, text)
+
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_post_draft_comment.py
+++ b/tests/unit/test_post_draft_comment.py
@@ -1,0 +1,126 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import patch, AsyncMock
+
+from gerrit_mcp_server import main
+
+
+class TestPostDraftComment(unittest.TestCase):
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_post_draft_comment_success(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.return_value = json.dumps({"id": "draft-abc123"})
+
+            result = await main.post_draft_comment(
+                change_id="456",
+                file_path="src/main.py",
+                line_number=10,
+                message="This needs a fix.",
+                gerrit_base_url="https://gerrit-review.googlesource.com",
+            )
+
+            self.assertIn("Draft comment created on CL 456", result[0]["text"])
+            self.assertIn("src/main.py", result[0]["text"])
+
+            mock_run_curl.assert_called_once()
+            args, kwargs = mock_run_curl.call_args
+            curl_args = args[0]
+            payload = json.loads(curl_args[curl_args.index("--data") + 1])
+            self.assertEqual(payload["path"], "src/main.py")
+            self.assertEqual(payload["line"], 10)
+            self.assertEqual(payload["message"], "This needs a fix.")
+            self.assertTrue(payload["unresolved"])
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_post_draft_comment_with_suggestion(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.return_value = json.dumps({"id": "draft-abc123"})
+
+            result = await main.post_draft_comment(
+                change_id="456",
+                file_path="src/main.py",
+                line_number=10,
+                message="Consider this instead:",
+                suggestion="new_code_here()",
+                gerrit_base_url="https://gerrit-review.googlesource.com",
+            )
+
+            self.assertIn("Draft comment created", result[0]["text"])
+
+            args, _ = mock_run_curl.call_args
+            curl_args = args[0]
+            payload = json.loads(curl_args[curl_args.index("--data") + 1])
+            self.assertIn("```suggestion", payload["message"])
+            self.assertIn("new_code_here()", payload["message"])
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_post_draft_comment_with_range(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.return_value = json.dumps({"id": "draft-abc123"})
+
+            result = await main.post_draft_comment(
+                change_id="456",
+                file_path="src/main.py",
+                line_number=10,
+                message="Multi-line comment",
+                start_line=8,
+                start_character=0,
+                end_line=12,
+                end_character=5,
+                gerrit_base_url="https://gerrit-review.googlesource.com",
+            )
+
+            self.assertIn("Draft comment created", result[0]["text"])
+
+            args, _ = mock_run_curl.call_args
+            curl_args = args[0]
+            payload = json.loads(curl_args[curl_args.index("--data") + 1])
+            self.assertEqual(payload["range"]["start_line"], 8)
+            self.assertEqual(payload["range"]["end_line"], 12)
+            # line should equal end_line when range is provided
+            self.assertEqual(payload["line"], 12)
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_post_draft_comment_no_id_in_response(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.return_value = json.dumps({"error": "something"})
+
+            result = await main.post_draft_comment(
+                change_id="456",
+                file_path="src/main.py",
+                line_number=10,
+                message="test",
+                gerrit_base_url="https://gerrit-review.googlesource.com",
+            )
+
+            self.assertIn("Failed to create draft comment", result[0]["text"])
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_post_draft_comment_exception(self, mock_run_curl):
+        async def run_test():
+            mock_run_curl.side_effect = Exception("Network error")
+
+            with self.assertRaises(Exception):
+                await main.post_draft_comment(
+                    change_id="456",
+                    file_path="src/main.py",
+                    line_number=10,
+                    message="test",
+                    gerrit_base_url="https://gerrit-review.googlesource.com",
+                )
+
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add four new MCP tools for managing Gerrit draft comments:
- post_draft_comment: create drafts with optional range and suggestion support
- list_draft_comments: list all drafts on a CL grouped by file
- delete_draft_comment: delete a single draft by ID
- delete_draft_comments: delete all drafts on a CL

Includes unit tests for all new tools.