### PR TITLE
Switch get_file_diff from /patch to structured /diff endpoint with pre-computed line numbers

### DIFF
--- a/gerrit_mcp_server/main.py
+++ b/gerrit_mcp_server/main.py
@@ -495,13 +495,71 @@ async def get_file_diff(
     gerrit_hosts = config.get("gerrit_hosts", [])
     base_url = _normalize_gerrit_url(_get_gerrit_base_url(gerrit_base_url), gerrit_hosts)
     encoded_file_path = quote(file_path, safe="")
-    url = f"{base_url}/changes/{change_id}/revisions/current/patch?path={encoded_file_path}"
+    url = f"{base_url}/changes/{change_id}/revisions/current/files/{encoded_file_path}/diff"
 
-    diff_base64 = await run_curl([url], base_url)
-    # The response is a base64 encoded string, we need to decode it.
-    # The result from run_curl is already a string, so we encode it back to bytes for b64decode
-    diff_text = base64.b64decode(diff_base64.encode("utf-8")).decode("utf-8")
-    return [{"type": "text", "text": diff_text}]
+    result_str = await run_curl([url], base_url)
+    try:
+        diff_json = json.loads(result_str)
+    except json.JSONDecodeError:
+        return [{"type": "text", "text": f"Failed to parse diff response.\n{result_str}"}]
+
+    return [{"type": "text", "text": _format_structured_diff(file_path, diff_json)}]
+
+
+def _build_diff_header(file_path: str, diff_json: dict) -> str:
+    meta_a = diff_json.get("meta_a")
+    meta_b = diff_json.get("meta_b")
+    change_type = diff_json.get("change_type", "MODIFIED")
+
+    header = f"diff {file_path} ({change_type})"
+    if meta_a:
+        header += f"\nold: {meta_a.get('name', file_path)} ({meta_a.get('lines', '?')} lines)"
+    if meta_b:
+        header += f"\nnew: {meta_b.get('name', file_path)} ({meta_b.get('lines', '?')} lines)"
+    return header
+
+
+def _format_structured_diff(file_path: str, diff_json: dict) -> str:
+    """Formats Gerrit's structured diff JSON into annotated text with line numbers.
+
+    We pre-compute line numbers instead of returning raw JSON or unified diffs
+    because LLMs frequently miscalculate line numbers from hunk headers
+    (e.g. @@ -10,5 +12,7 @@), leading to review comments posted on wrong lines.
+
+    Each line is prefixed with its new-file line number so that consumers can
+    directly use it when posting review comments via post_draft_comment/post_review_comment.
+
+    Format:
+        <new_line_number>:  unchanged line
+        <new_line_number>: +added line
+                         : -deleted line
+    """
+    lines = [_build_diff_header(file_path, diff_json), ""]
+
+    old_line = 1
+    new_line = 1
+
+    for chunk in diff_json.get("content", []):
+        for text in chunk.get("ab", []):
+            lines.append(f"{new_line:>6}:  {text}")
+            old_line += 1
+            new_line += 1
+
+        for text in chunk.get("a", []):
+            lines.append(f"      : -{text}")
+            old_line += 1
+
+        for text in chunk.get("b", []):
+            lines.append(f"{new_line:>6}: +{text}")
+            new_line += 1
+
+        if "skip" in chunk:
+            skip_count = chunk["skip"]
+            lines.append(f"  ... ({skip_count} unchanged lines omitted)")
+            old_line += skip_count
+            new_line += skip_count
+
+    return "\n".join(lines)
 
 
 @mcp.tool()

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -165,17 +165,25 @@ async def test_list_change_files_no_files(mock_run_curl):
 @pytest.mark.asyncio
 async def test_get_file_diff(mock_run_curl):
     """Tests retrieving the diff of a file."""
-    diff_text = "diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -1,1 +1,1 @@\n-hello\n+world"
-    import base64
-    encoded_diff = base64.b64encode(diff_text.encode("utf-8")).decode("utf-8")
-    mock_run_curl.return_value = encoded_diff
+    diff_json = {
+        "meta_a": {"name": "file.txt", "content_type": "text/plain", "lines": 1},
+        "meta_b": {"name": "file.txt", "content_type": "text/plain", "lines": 1},
+        "change_type": "MODIFIED",
+        "content": [
+            {"a": ["hello"], "b": ["world"]},
+        ],
+    }
+    mock_run_curl.return_value = json.dumps(diff_json)
 
     result = await main.get_file_diff(
         gerrit_base_url="https://fuchsia-review.googlesource.com",
         change_id="123",
         file_path="file.txt",
     )
-    assert result[0]["text"] == diff_text
+    text = result[0]["text"]
+    assert "file.txt (MODIFIED)" in text
+    assert "      : -hello" in text
+    assert "     1: +world" in text
 
 @pytest.mark.asyncio
 async def test_list_change_comments(mock_run_curl):

--- a/tests/unit/test_get_file_diff.py
+++ b/tests/unit/test_get_file_diff.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest
 from unittest.mock import patch, AsyncMock
 import asyncio
-import base64
 
 from gerrit_mcp_server import main
 
@@ -27,11 +27,16 @@ class TestGetFileDiff(unittest.TestCase):
             # Arrange
             change_id = "54321"
             file_path = "src/main.py"
-            diff_content = "diff --git a/src/main.py b/src/main.py\n--- a/src/main.py\n+++ b/src/main.py\n@@ -1,1 +1,1 @@\n-old line\n+new line"
-            encoded_diff = base64.b64encode(diff_content.encode("utf-8")).decode(
-                "utf-8"
-            )
-            mock_run_curl.return_value = encoded_diff
+            diff_json = {
+                "meta_a": {"name": "src/main.py", "content_type": "text/x-python", "lines": 3},
+                "meta_b": {"name": "src/main.py", "content_type": "text/x-python", "lines": 3},
+                "change_type": "MODIFIED",
+                "content": [
+                    {"ab": ["import os", ""]},
+                    {"a": ["old line"], "b": ["new line"]},
+                ],
+            }
+            mock_run_curl.return_value = json.dumps(diff_json)
             gerrit_base_url = "https://my-gerrit.com"
 
             # Act
@@ -40,7 +45,75 @@ class TestGetFileDiff(unittest.TestCase):
             )
 
             # Assert
-            self.assertEqual(result[0]["text"], diff_content)
+            text = result[0]["text"]
+            self.assertIn("src/main.py (MODIFIED)", text)
+            # Unchanged lines should have new-file line numbers
+            self.assertIn("     1:  import os", text)
+            self.assertIn("     2:  ", text)
+            # Deleted line has no new-file line number
+            self.assertIn("      : -old line", text)
+            # Added line has new-file line number
+            self.assertIn("     3: +new line", text)
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_get_file_diff_new_file(self, mock_run_curl):
+        async def run_test():
+            change_id = "99999"
+            file_path = "new_file.py"
+            diff_json = {
+                "meta_b": {"name": "new_file.py", "content_type": "text/x-python", "lines": 3},
+                "change_type": "ADDED",
+                "content": [
+                    {"b": ["line one", "line two", "line three"]},
+                ],
+            }
+            mock_run_curl.return_value = json.dumps(diff_json)
+
+            result = await main.get_file_diff(
+                change_id, file_path, gerrit_base_url="https://my-gerrit.com"
+            )
+
+            text = result[0]["text"]
+            self.assertIn("new_file.py (ADDED)", text)
+            self.assertIn("     1: +line one", text)
+            self.assertIn("     2: +line two", text)
+            self.assertIn("     3: +line three", text)
+
+        asyncio.run(run_test())
+
+    @patch("gerrit_mcp_server.main.run_curl", new_callable=AsyncMock)
+    def test_get_file_diff_with_skip(self, mock_run_curl):
+        async def run_test():
+            change_id = "11111"
+            file_path = "big_file.py"
+            diff_json = {
+                "meta_a": {"name": "big_file.py", "content_type": "text/x-python", "lines": 200},
+                "meta_b": {"name": "big_file.py", "content_type": "text/x-python", "lines": 201},
+                "change_type": "MODIFIED",
+                "content": [
+                    {"ab": ["first line"]},
+                    {"skip": 95},
+                    {"a": ["old middle"], "b": ["new middle 1", "new middle 2"]},
+                    {"skip": 100},
+                    {"ab": ["last line"]},
+                ],
+            }
+            mock_run_curl.return_value = json.dumps(diff_json)
+
+            result = await main.get_file_diff(
+                change_id, file_path, gerrit_base_url="https://my-gerrit.com"
+            )
+
+            text = result[0]["text"]
+            self.assertIn("     1:  first line", text)
+            self.assertIn("(95 unchanged lines omitted)", text)
+            self.assertIn("      : -old middle", text)
+            self.assertIn("    97: +new middle 1", text)
+            self.assertIn("    98: +new middle 2", text)
+            self.assertIn("(100 unchanged lines omitted)", text)
+            self.assertIn("   199:  last line", text)
 
         asyncio.run(run_test())
 


### PR DESCRIPTION
LLMs frequently miscalculate line numbers from unified diff hunk headers
(e.g. @@ -10,5 +12,7 @@), causing review comments to be posted on wrong
lines. Switch to Gerrit's /files/{path}/diff endpoint which returns
structured JSON, and format it with explicit new-file line numbers that
can be used directly with post_draft_comment/post_review_comment.
