### PR TITLE
Add /a/ prefix to Gerrit API URLs for authenticated access

### DIFF
--- a/gerrit_mcp_server/main.py
+++ b/gerrit_mcp_server/main.py
@@ -168,6 +168,13 @@ def _normalize_gerrit_url(url: str, gerrit_hosts: List[Dict[str, Any]]) -> str:
 async def run_curl(args: List[str], gerrit_base_url: str) -> str:
     """Executes a curl command and returns the output."""
     config = load_gerrit_config()
+    # Gerrit requires /a/ prefix in the URL path for authenticated API access.
+    args = [
+        arg.replace(f"{gerrit_base_url}/", f"{gerrit_base_url}/a/", 1)
+        if arg.startswith(gerrit_base_url) and "/a/" not in arg
+        else arg
+        for arg in args
+    ]
     command = get_curl_command_for_gerrit_url(gerrit_base_url, config) + args
     with open(LOG_FILE_PATH, "a") as log_file:
         log_file.write(f"[gerrit-mcp-server] Executing: {" ".join(command)}\n")


### PR DESCRIPTION
Per Gerrit REST API docs, all endpoints assume anonymous access by default. Users must prefix the URL path with /a/ to authenticate with HTTP basic credentials or cookies. Without /a/, Gerrit ignores any auth headers and returns only publicly visible data (which may be nothing at all).

The /a/ is injected in run_curl so individual tools don't need to handle it. Includes an idempotency guard to avoid double /a/ if the config URL already contains it.