### PR TITLE
Fix post_review_comment to support in-thread replies

### DIFF
--- a/gerrit_mcp_server/gerrit_command_argument_defs.json
+++ b/gerrit_mcp_server/gerrit_command_argument_defs.json
@@ -213,6 +213,11 @@
       "labels": {
         "type": "object",
         "description": "A dictionary of labels to apply to the review (e.g., {'Verified': 1})."
+      },
+      "in_reply_to": {
+        "type": "string",
+        "description": "The ID of the comment to reply to. Use list_change_comments to get comment IDs. When set, the comment is posted as a reply in the existing comment thread.",
+        "required": false
       }
     }
   }

--- a/gerrit_mcp_server/main.py
+++ b/gerrit_mcp_server/main.py
@@ -536,8 +536,9 @@ async def list_change_comments(
             author = comment.get("author", {}).get("name", "Unknown")
             timestamp = comment.get("updated", "No date")
             message = comment["message"]
+            comment_id = comment.get("id", "")
             status = "UNRESOLVED" if comment.get("unresolved", False) else "RESOLVED"
-            output += f"L{line}: [{author}] ({timestamp}) - {status}\n"
+            output += f"L{line}: [{author}] ({timestamp}) - {status} (id: {comment_id})\n"
             output += f"  {message}\n"
 
     if not found_comments:
@@ -1156,6 +1157,7 @@ async def post_review_comment(
     unresolved: bool = True,
     gerrit_base_url: Optional[str] = None,
     labels: Optional[Dict[str, int]] = None,
+    in_reply_to: Optional[str] = None,
 ):
     """
     Posts a review comment on a specific line of a file in a CL.
@@ -1165,20 +1167,37 @@ async def post_review_comment(
     base_url = _normalize_gerrit_url(_get_gerrit_base_url(gerrit_base_url), gerrit_hosts)
     url = f"{base_url}/changes/{change_id}/revisions/current/review"
 
+    comment_input = {
+        "line": line_number,
+        "message": message,
+        "unresolved": unresolved,
+    }
+    if in_reply_to:
+        comment_input["in_reply_to"] = in_reply_to
+        # Gerrit threads comments by (file, line, range). To reply in-thread,
+        # we must match the parent comment's range. Fetch it from the API.
+        try:
+            comments_url = f"{base_url}/changes/{change_id}/comments"
+            comments_str = await run_curl([comments_url], base_url)
+            comments_by_file = json.loads(comments_str)
+            for comment in comments_by_file.get(file_path, []):
+                if comment.get("id") == in_reply_to:
+                    if "range" in comment:
+                        comment_input["range"] = comment["range"]
+                    if "line" in comment:
+                        comment_input["line"] = comment["line"]
+                    break
+        except Exception:
+            pass  # fall back to line_number if lookup fails
+
     payload = {
         "comments": {
-            file_path: [
-                {
-                    "line": line_number,
-                    "message": message,
-                    "unresolved": unresolved,
-                }
-            ]
+            file_path: [comment_input]
         },
     }
     if labels:
         payload["labels"] = labels
-    
+
     args = _create_post_args(url, payload)
 
     try:


### PR DESCRIPTION
## Summary

- `post_review_comment` cannot reply to existing comment threads — every comment is posted as a new standalone thread on the given line
- Add `in_reply_to` parameter and auto-fetch parent comment's `range` to enable proper threading
- Include comment IDs in `list_change_comments` output so callers can obtain the UUID needed for `in_reply_to`

## Problem

When an AI agent processes code review feedback and replies to reviewer comments via `post_review_comment`, the replies appear as disconnected standalone comments instead of threaded responses. This makes code review conversations hard to follow.

The root cause has two layers:

1. **No `in_reply_to` parameter** — the Gerrit REST API supports `in_reply_to` in `CommentInput`, but the tool doesn't expose it
2. **Missing `range` matching** — even with `in_reply_to` set, Gerrit UI does not render the reply in-thread unless the reply's positional metadata (`range`) matches the parent comment. Gerrit identifies threads by `(file, line, range)`, not by `in_reply_to` alone. When a reviewer highlights a code range, the reply must include that same range.

## Changes

### `list_change_comments`
- Include comment `id` in output (e.g., `(id: abc123_def456)`) so callers know which UUID to pass to `in_reply_to`

### `post_review_comment`
- Add optional `in_reply_to` parameter accepting a parent comment UUID
- When `in_reply_to` is set, automatically fetch the parent comment's metadata from `/changes/{id}/comments` and copy its `range` and `line` into the reply — this ensures Gerrit UI renders the reply inside the correct thread
- Falls back to the provided `line_number` if the parent comment lookup fails

### `gerrit_command_argument_defs.json`
- Add `in_reply_to` parameter definition

## Test plan

Tested against a live Gerrit 3.x instance:
- [x] Reply to a line-level comment (no range) — appears in-thread
- [x] Reply to a range-level comment (highlighted code) — appears in-thread
- [x] `list_change_comments` shows comment IDs in output
- [x] Fallback: if `in_reply_to` is omitted, behavior is unchanged (new standalone comment)
- [x] Fallback: if parent comment lookup fails, comment is still posted (at given line)

Fixes #13