### PR TITLE
Redact credentials from server.log

### DIFF
--- a/gerrit_mcp_server/main.py
+++ b/gerrit_mcp_server/main.py
@@ -261,6 +261,18 @@ def _normalize_gerrit_url(url: str, gerrit_hosts: List[Dict[str, Any]]) -> str:
     return normalized_url
 
 
+def _redact_command_for_logging(command: List[str]) -> List[str]:
+    """Returns a copy of a curl command with credentials masked for logging."""
+    redacted = list(command)
+    for i, arg in enumerate(redacted):
+        if arg == "--user" and i + 1 < len(redacted):
+            user_part = redacted[i + 1].split(":", 1)[0]
+            redacted[i + 1] = f"{user_part}:***REDACTED***"
+        elif arg == "-b" and i + 1 < len(redacted):
+            redacted[i + 1] = "***REDACTED***"
+    return redacted
+
+
 async def run_curl(args: List[str], gerrit_base_url: str) -> str:
     """Executes a curl command and returns the output."""
     config = load_gerrit_config()
@@ -268,8 +280,9 @@ async def run_curl(args: List[str], gerrit_base_url: str) -> str:
     command = (
         get_curl_command_for_gerrit_url(gerrit_base_url, config) + obs_headers + args
     )
+    redacted_command = " ".join(_redact_command_for_logging(command))
     with open(LOG_FILE_PATH, "a") as log_file:
-        log_file.write(f"[gerrit-mcp-server] Executing: {' '.join(command)}\n")
+        log_file.write(f"[gerrit-mcp-server] Executing: {redacted_command}\n")
 
     process = await asyncio.create_subprocess_exec(
         *command,


### PR DESCRIPTION
## Problem

`run_curl()` in `main.py` writes the full curl command line to `server.log` before executing it:

[gerrit-mcp-server] Executing: curl --user <username>:<auth_token> -L https://...

For the `http_basic` auth method, this puts the raw HTTP Basic Auth token in plaintext in a log file on disk on every single request. The `gitcookies` auth method has the same problem — the session cookie passed via `-b <cookie>` ends up in the log the same way.

## Fix

Mask the credential-bearing arguments before writing the log line. The actual curl invocation is unchanged — only what gets written to `server.log` is redacted. `--user user:token` becomes `--user user:***REDACTED***`, and `-b <cookie>` becomes
`-b ***REDACTED***`.

## Testing

Ran the server locally with `http_basic` auth configured, made a real authenticated call against a Gerrit instance  `get_change_details`), and confirmed: - the request still succeeds (auth unaffected) - `server.log` now shows `--user <username>:***REDACTED***` instead of  the plaintext token